### PR TITLE
Improvements to your WPML compatibility code

### DIFF
--- a/includes/compatibility/civicrm.wpml.php
+++ b/includes/compatibility/civicrm.wpml.php
@@ -39,11 +39,10 @@ class CiviCRM_For_WordPress_Compat_WPML {
   /**
    * @var array
    * Collected rewrites.
-   * @since 5.66
+   * @since 5.72
    * @access private
    */
   private $rewrites = [];
-
 
   /**
    * Instance constructor.
@@ -83,13 +82,218 @@ class CiviCRM_For_WordPress_Compat_WPML {
     }
 
     // Register WPML compatibility callbacks.
-    add_action('civicrm_after_rewrite_rules', [$this, 'rewrite_rules_wpml'], 10, 2);
-    add_filter('icl_ls_languages', [$this, 'rewrite_civicrm_urls_wpml']);
+    add_action('civicrm_after_rewrite_rules', [$this, 'rewrite_rules'], 10, 2);
+    add_filter('icl_ls_languages', [$this, 'rewrite_civicrm_urls']);
 
     // Register specific CiviCRM callbacks.
-    add_filter('civicrm/core/locale', [$this, 'locale_filter'], 10, 2);
     add_filter('civicrm/basepage/match', [$this, 'basepage_match'], 10, 2);
     add_filter('civicrm/core/url/base', [$this, 'base_url_filter'], 10, 2);
+    add_filter('civicrm/core/locale', [$this, 'locale_filter'], 10, 2);
+
+  }
+
+  /**
+   * Setup the rewrite rules for WPML.
+   *
+   * @since 5.72
+   *
+   * @param bool $flush_rewrite_rules True if rules flushed, false otherwise.
+   * @param WP_Post $basepage The Base Page post object.
+   */
+  public function rewrite_rules($flush_rewrite_rules, $basepage) {
+
+    global $sitepress;
+
+    /*
+     * Collect all rewrite rules into an array.
+     *
+     * Because the array of specific Post IDs is added *after* the array of
+     * paths for the Base Page ID, those specific rewrite rules will "win" over
+     * the more general Base Page rules.
+     */
+    $collected_rewrites = [];
+
+    // Grab information about configuration.
+    $wpml_active = apply_filters('wpml_active_languages', NULL);
+
+    // Obtain language negotiation setting.
+    $wpml_negotiation = apply_filters('wpml_setting', NULL, 'language_negotiation_type');
+
+    // Support prefixes for a single Base Page.
+    $basepage_url = get_permalink($basepage->ID);
+    $basepage_raw_url = $this->remove_language_from_link($basepage_url, $sitepress, $wpml_negotiation);
+    foreach ($wpml_active as $slug => $data) {
+      $language_url = $sitepress->convert_url($basepage_raw_url, $slug);
+      $parsed_url = wp_parse_url($language_url, PHP_URL_PATH);
+      $regex_path = substr($parsed_url, 1);
+
+      // Determine if there is a translation path.
+      $post_id = apply_filters('wpml_object_id', $basepage->ID, 'page', FALSE, $slug);
+      if ($post_id == $basepage->ID) {
+        $collected_rewrites[$post_id][] = $regex_path;
+      }
+      else {
+        $url = get_permalink($post_id);
+        $url = $sitepress->convert_url($url, $slug);
+        $parsed_url = wp_parse_url($url, PHP_URL_PATH);
+        $regex_path = substr($parsed_url, 1);
+        $collected_rewrites[$post_id][] = $regex_path;
+      }
+
+    }
+
+    // Make collection unique and add remaining rewrite rules.
+    $this->rewrites = array_map('array_unique', $collected_rewrites);
+    if (!empty($this->rewrites)) {
+      foreach ($this->rewrites as $post_id => $rewrite) {
+        foreach ($rewrite as $path) {
+          add_rewrite_rule(
+            '^' . $path . '([^?]*)?',
+            'index.php?page_id=' . $post_id . '&civiwp=CiviCRM&q=civicrm%2F$matches[1]',
+            'top'
+          );
+        }
+      }
+    }
+
+    // Maybe force flush.
+    if ($flush_rewrite_rules) {
+      flush_rewrite_rules();
+    }
+
+  }
+
+  /**
+   * icl_ls_languages WPML Filter
+   * Rewrite all CiviCRM URLs to contain the proper language structure based on the WPML settings
+   *
+   * @since 5.72
+   *
+   * @param array $languages passed by WPML to modify current path
+   */
+  public function rewrite_civicrm_urls($languages) {
+
+    // Get the post slug.
+    global $post;
+    $post_slug = isset($post->post_name) ? $post->post_name : '';
+    if (empty($post_slug) && isset($post->post_name)) {
+      $post_slug = $post->post_name;
+    }
+
+    // Get CiviCRM basepage slug.
+    $civicrm_slug = apply_filters('civicrm_basepage_slug', 'civicrm');
+
+    // Obtain WPML language negotiation setting.
+    $wpml_negotiation = apply_filters('wpml_setting', NULL, 'language_negotiation_type');
+
+    // If this is a CiviCRM Page then let's modify the actual path.
+    if ($post_slug == $civicrm_slug) {
+      global $sitepress;
+      $current_url = explode("?", $_SERVER['REQUEST_URI']);
+      $civicrm_url = get_site_url(NULL, $current_url[0]);
+
+      // Remove language from path.
+      $wpml_negotiation = apply_filters('wpml_setting', NULL, 'language_negotiation_type');
+      $civicrm_url = $this->remove_language_from_link($civicrm_url, $sitepress, $wpml_negotiation);
+
+      // Build query string.
+      $qs = [];
+      parse_str($_SERVER["QUERY_STRING"], $qs);
+
+      // Strip any WPML languages if they exist.
+      unset($qs['lang']);
+      $query = http_build_query($qs);
+
+      // Rebuild CiviCRM links for each language.
+      foreach ($languages as &$language) {
+        $url = apply_filters('wpml_permalink', $civicrm_url, $language['language_code']);
+        if (!empty($query)) {
+          if ($wpml_negotiation == 3 && strpos($url, '?') !== FALSE) {
+            $language['url'] = $url . '&' . $query;
+          }
+          else {
+            $language['url'] = $url . '?' . $query;
+          }
+        }
+      }
+    }
+
+    return $languages;
+
+  }
+
+  /**
+   * Checks WPML for CiviCRM Base Page matches.
+   *
+   * @since 5.72
+   *
+   * @param bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
+   * @param int $post_id The WordPress Post ID to check.
+   * @return bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
+   */
+  public function basepage_match($is_basepage, $post_id) {
+
+    // Bail if this is already the Base Page.
+    if ($is_basepage) {
+      return $is_basepage;
+    }
+
+    // Bail if there are no rewrites.
+    if (empty($this->rewrites)) {
+      return $is_basepage;
+    }
+
+    // Check rewrites to see if we have a match with this Post ID.
+    if (isset($this->rewrites[$post_id]) && !empty($this->rewrites[$post_id])) {
+      $is_basepage = TRUE;
+    }
+
+    return $is_basepage;
+
+  }
+
+  /**
+   * Filters the CiviCRM Base URL for the current language reported by WPML
+   *
+   * Only filters URLs that point to the front-end/back-end, since WordPress admin URLs are
+   * rewritten by WPML.
+   *
+   * @since 5.72
+   *
+   * @param str $url The URL as built by CiviCRM.
+   * @param bool $admin_request True if building an admin URL, false otherwise.
+   * @return str $url The URL as modified by WPML.
+   */
+  public function base_url_filter($url, $admin_request) {
+
+    // Skip when not defined.
+    if (empty($url)) {
+      return $url;
+    }
+
+    // Grab WPML language slug.
+    $slug = '';
+    $languages = apply_filters('wpml_active_languages', NULL);
+    foreach ($languages as $id => $language) {
+      if ($language['active']) {
+        $slug = $id;
+        break;
+      }
+    }
+
+    if (empty($slug)) {
+      return $url;
+    }
+
+    // Obtain language negotiation setting.
+    $wpml_negotiation = apply_filters('wpml_setting', NULL, 'language_negotiation_type');
+
+    // Build the modified URL.
+    global $sitepress;
+    $raw_url = $this->remove_language_from_link($url, $sitepress, $wpml_negotiation);
+    $language_url = $sitepress->convert_url($raw_url, $slug);
+
+    return $language_url;
 
   }
 
@@ -116,218 +320,9 @@ class CiviCRM_For_WordPress_Compat_WPML {
   }
 
   /**
-   * Checks WPML for CiviCRM Base Page matches.
-   *
-   * @since 5.70
-   *
-   * @param bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
-   * @param int $post_id The WordPress Post ID to check.
-   * @return bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
-   */
-  public function basepage_match($is_basepage, $post_id) {
-
-    // Bail if this is already the Base Page.
-    if ($is_basepage) {
-      return $is_basepage;
-    }
-
-    // Bail if there are no rewrites.
-    if (empty($this->rewrites)) {
-      return $is_basepage;
-    }
-
-    // Check rewrites to see if we have a match with this $post_id
-    if (isset($this->rewrites[$post_id]) && !empty($this->rewrites[$post_id])) {
-      $is_basepage = TRUE;
-    }
-
-    return $is_basepage;
-
-  }
-
-  /**
-   * Filters the CiviCRM Base URL for the current language reported by WPML
-   *
-   * Only filters URLs that point to the front-end/back-end, since WordPress admin URLs are
-   * rewritten by WPML.
-   *
-   * @since 5.70
-   *
-   * @param str $url The URL as built by CiviCRM.
-   * @param bool $admin_request True if building an admin URL, false otherwise.
-   * @return str $url The URL as modified by WPML.
-   */
-  public function base_url_filter($url, $admin_request) {
-
-    // Skip when not defined.
-    if (empty($url)) {
-      return $url;
-    }
-
-    // Grab WPML language slug.
-    $slug = '';
-    $languages = apply_filters('wpml_active_languages', NULL);
-
-    foreach ($languages as $id => $language) {
-      if ($language['active']) {
-        $slug = $id;
-        break;
-      }
-    }
-
-    if (empty($slug)) {
-      return $url;
-    }
-
-    // Obtain lagnuage negotiation setting
-    $wpml_negotiation = apply_filters('wpml_setting', NULL, 'language_negotiation_type');
-
-    // Build the modified URL.
-    global $sitepress;
-    $raw_url = $this->wpml_remove_language_from_url($url, $sitepress, $wpml_negotiation);
-    $language_url = $sitepress->convert_url($raw_url, $slug);
-
-    return $language_url;
-
-  }
-
-  /**
-   * Setup the rewrite rules for WPML.
-   *
-   * @since 5.70
-   *
-   * @param bool $flush_rewrite_rules True if rules flushed, false otherwise.
-   * @param WP_Post $basepage The Base Page post object.
-   */
-  public function rewrite_rules_wpml($flush_rewrite_rules, $basepage) {
-
-    // Bail if WPML is not present.
-    if (!defined('ICL_SITEPRESS_VERSION')) {
-      return;
-    }
-
-    /*
-     * Collect all rewrite rules into an array.
-     *
-     * Because the array of specific Post IDs is added *after* the array of
-     * paths for the Base Page ID, those specific rewrite rules will "win" over
-     * the more general Base Page rules.
-     */
-    global $sitepress;
-    $collected_rewrites = [];
-
-    // Grab information about configuration
-    $wpml_active = apply_filters('wpml_active_languages', NULL);
-
-    // Obtain lagnuage negotiation setting
-    $wpml_negotiation = apply_filters('wpml_setting', NULL, 'language_negotiation_type');
-
-    // Support prefixes for a single Base Page.
-    $basepage_url = get_permalink($basepage->ID);
-    $basepage_raw_url = $this->wpml_remove_language_from_url($basepage_url, $sitepress, $wpml_negotiation);
-    foreach ($wpml_active as $slug => $data) {
-      $language_url = $sitepress->convert_url($basepage_raw_url, $slug);
-      $parsed_url = wp_parse_url($language_url, PHP_URL_PATH);
-      $regex_path = substr($parsed_url, 1);
-
-      // Determine if there is a translation path
-      $post_id = apply_filters('wpml_object_id', $basepage->ID, 'page', FALSE, $slug);
-      if ($post_id == $basepage->ID) {
-        $collected_rewrites[$post_id][] = $regex_path;
-      }
-      else {
-        $url = get_permalink($post_id);
-        $url = $sitepress->convert_url($url, $slug);
-        $parsed_url = wp_parse_url($url, PHP_URL_PATH);
-        $regex_path = substr($parsed_url, 1);
-        $collected_rewrites[$post_id][] = $regex_path;
-      }
-
-    };
-
-    // Make collection unique and add remaining rewrite rules.
-    $this->rewrites = array_map('array_unique', $collected_rewrites);
-    if (!empty($rewrites)) {
-      foreach ($rewrites as $post_id => $rewrite) {
-        foreach ($rewrite as $path) {
-          add_rewrite_rule(
-            '^' . $path . '([^?]*)?',
-            'index.php?page_id=' . $post_id . '&civiwp=CiviCRM&q=civicrm%2F$matches[1]',
-            'top'
-          );
-        }
-      }
-    }
-
-    // Maybe force flush.
-    if ($flush_rewrite_rules) {
-      flush_rewrite_rules();
-    }
-  }
-
-  /**
-   * icl_ls_languages WPML Filter
-   * Rewrite all CiviCRM URLs to contain the proper language structure based on the WPML settings
-   *
-   * @since 5.70
-   *
-   * @param array $languages passed by WPML to modify current path
-   */
-  public function rewrite_civicrm_urls_wpml($languages) {
-
-    // Get the post slug
-    global $post;
-    $post_slug = isset($post->post_name) ? $post->post_name : '';
-    if (empty($post_slug) && isset($post->post_name)) {
-      $post_slug = $post->post_name;
-    }
-
-    // Get CiviCRM basepage slug
-    $civicrm_slug = apply_filters('civicrm_basepage_slug', 'civicrm');
-
-    // Obtain WPML lagnuage negotiation setting
-    $wpml_negotiation = apply_filters('wpml_setting', NULL, 'language_negotiation_type');
-
-    // If this is a CiviCRM Page then let's modify the actual path
-    if ($post_slug == $civicrm_slug) {
-      global $sitepress;
-      $current_url = explode("?", $_SERVER['REQUEST_URI']);
-      $civicrm_url = get_site_url(NULL, $current_url[0]);
-
-      // Remove language from path
-      $wpml_negotiation = apply_filters('wpml_setting', NULL, 'language_negotiation_type');
-      $civicrm_url = $this->wpml_remove_language_from_url($civicrm_url, $sitepress, $wpml_negotiation);
-
-      // Build query string
-      $qs = [];
-      parse_str($_SERVER["QUERY_STRING"], $qs);
-
-      // Strip any WPML languages if they exist
-      unset($qs['lang']);
-      $query = http_build_query($qs);
-
-      // Rebuild CiviCRM links for each language
-      foreach ($languages as &$language) {
-        $url = apply_filters('wpml_permalink', $civicrm_url, $language['language_code']);
-
-        if (!empty($query)) {
-          if ($wpml_negotiation == 3 && strpos($url, '?') !== FALSE) {
-            $language['url'] = $url . '&' . $query;
-          }
-          else {
-            $language['url'] = $url . '?' . $query;
-          }
-        }
-      }
-    }
-
-    return $languages;
-  }
-
-  /**
    * Remove Language from URL based on WPML configuration
    *
-   * @since 5.70
+   * @since 5.72
    *
    * @param $url passed URL to strip language from
    * @param object $sitepress WPML class
@@ -335,8 +330,9 @@ class CiviCRM_For_WordPress_Compat_WPML {
    *
    * @return $url base page url without language
    */
-  private function wpml_remove_language_from_url($url, $sitepress, $wpml_negotiation) {
-    $lang = apply_filters( 'wpml_current_language', null );
+  private function remove_language_from_link($url, $sitepress, $wpml_negotiation) {
+
+    $lang = apply_filters('wpml_current_language', NULL);
     if ($lang) {
       if ($wpml_negotiation == 1) {
         $url = str_replace('/' . $lang . '/', '/', $url);
@@ -347,6 +343,7 @@ class CiviCRM_For_WordPress_Compat_WPML {
     }
 
     return $url;
+
   }
 
 }

--- a/includes/compatibility/civicrm.wpml.php
+++ b/includes/compatibility/civicrm.wpml.php
@@ -102,7 +102,7 @@ class CiviCRM_For_WordPress_Compat_WPML {
    */
   public function rewrite_rules($flush_rewrite_rules, $basepage) {
 
-    global $sitepress, $wpml_url_filters, $wpml_url_converter;
+    global $sitepress, $wpml_url_filters;
 
     /*
      * Collect all rewrite rules into an array.
@@ -194,7 +194,6 @@ class CiviCRM_For_WordPress_Compat_WPML {
    */
   public function basepage_urls_rebuild($languages) {
 
-    // Get the current post.
     global $post, $sitepress;
 
     // We need the current Post object.
@@ -367,33 +366,6 @@ class CiviCRM_For_WordPress_Compat_WPML {
     }
 
     return $locale;
-
-  }
-
-  /**
-   * Remove Language from URL based on WPML configuration
-   *
-   * @since 5.72
-   *
-   * @param $url passed URL to strip language from
-   * @param object $sitepress WPML class
-   * @param int $wpml_negotiation language negotiation setting in WPML
-   *
-   * @return $url base page url without language
-   */
-  private function remove_language_from_link($url, $sitepress, $wpml_negotiation) {
-
-    $lang = apply_filters('wpml_current_language', NULL);
-    if ($lang) {
-      if ($wpml_negotiation == 1) {
-        $url = str_replace('/' . $lang . '/', '/', $url);
-      }
-      elseif ($wpml_negotiation == 3) {
-        $url = str_replace('lang=' . $lang, '', $url);
-      }
-    }
-
-    return $url;
 
   }
 


### PR DESCRIPTION
Hi @shaneonabike as I said on MM, this is complicated... so I'll start with the basics, move on to the more complicated and hope I don't lose you (or myself) along the way...

In a WPML installation, it appears that there are five possible places where the locale can be (or needs to be) set:

* WordPress "General Settings" will have a value from before WPML was activated.
* WordPress User Profile "Site Language" will also have a value from before WPML was activated.
* CiviCRM "Settings - Localisation" should be set to "Inherit CMS Language" etc.
* WPML "Site Languages" will have a value for "default language".
* WPML "Language Selector" in the admin bar, which can have the "all" slug that is not a language code.

(An extra complication for me as a U.K. resident is that WPML does not seem to distinguish between "English (UK)" and "English (US)" in the filters and callbacks because WPML passes round the language code not the locale. This means both are covered by the `en` language code whereas they should be  distinguished by their locale, e.g. `en_US` and `en_GB` respectively. I can't even add both "English (UK)" and "English (US)" as separate languages apparently *sad face emoji*)

The CiviCRM "Base Page" may or may not be translated. It seems that CiviCRM can only work when the "Base Page" has been translated. Each translation can have its own "slug" which does not need to be `langcode/civicrm`. The Rewrite Rules need to handle all these situation, as does the Base Page filter.

So in my testing with WPML's "Different languages in directories" setting, your code only handles "identical" CiviCRM Base Page URLs, i.e. `civicrm` (default),  `de/civicrm`, `fr/civicrm`, etc. It will not handle `civicrm` (default) `de/civicrm-de`, `fr/civicrm-fr`, etc and results in 404s. Furthermore, "internal" CiviCRM links (e.g. from an Event Info page to an Event Registration page) also result in 404s.

Switching to WPML's "Language name added as a parameter" setting breaks lots of things including CiviCRM admin URLs. The native CiviCRM `CRM_Utils_System::url()` method returns malformed URLs such as the following when called from the front end and targeting the back end:

```
https://civicrm.wpml.latest/wp-admin/admin.php?lang=en?page=CiviCRM&q=civicrm%2Fgroup&reset=1
https://civicrm.wpml.latest/wp-admin/admin.php?lang=en?page=CiviCRM&q=civicrm%2Fadmin&reset=1
```

See the links in the CiviCRM Admin Utilities menu in the admin bar for example. FWIW it seems kinda weird to me that the WPML allows "language-by-query-var" when WordPress Permalinks are not set to "Plain" - but it does. Polylang takes the more sensible approach and will not allow this.

What this suggests is that the current integration is not making use proper of WPML's API, or that there are shortcomings in WPML's API, or that there are incompatibilities with CiviCRM's URL building approach. Or a mixture of all three. Or we need to specify more clearly what will work and what won't and with what settings.

Because of the way that CiviCRM builds its URLs (which is clunky in its own way and which I have tried to improve over the years) my inclination is to disallow CiviCRM compatibility when this is the case. We already insist on some form of WordPress "Pretty Permalinks" for CiviCRM "Clean URLs" to work, so it seems reasonable to insist on WPML being set to something other than "Language name added as a parameter".

Indeed, when WPML is set to "Language name added as a parameter" and all languages have the same slug (which is very likely given that that is WPML's default) then the rewrite rules become:

```
[rewrites] => Array
  (
    [1833] => Array        --> Original
      (
        [0] => civicrm/
      )

    [1923] => Array        --> French
      (
        [0] => civicrm/
      )

    [1924] => Array        --> German
      (
        [0] => civicrm/
      )

  )
```

As you can see, with these rules "German" will always "win" and as a result we can _never have the combination_ of "Clean URLs" in CiviCRM and "Language name added as a parameter" in WPML. And I'd be really surprised if anyone wants to go back to pre "Clean URLs" and see the CiviCRM System Error all the time. So let's insist on "Different languages in directories" as a minimum requirement.

With this in mind, I have tried to make things more robust. Firstly, `remove_language_from_link()` does not seem necessary. WPML (with some persuasion) handles conversion of URLs between languages without the need to strip the existing language code manually. This is really important for code maintenance because it offloads handling any functionality changes to WPML.

Secondly, by default WPML filters permalinks fetched with the `get_permalink()` function to return the URL of the translated page for the current language. This is obviously problematic for building the Rewrite Rules because we need to retrieve the actual permalink for a page in a given language, regardless of the current language. Removing its filters does produce reliable and consistent results when building rules in different language contexts however. I'll ask the WPML folks to introduce a `get_me_the_permalink_without_your_filters()` function so we don't have to reach into their code to do so.

While building the Polylang integration, it became clear that a "cascading hierarchy" of Rewrite Rules was the only way to ensure that all possible CiviCRM URLs were handled gracefully. The net result was a rewrites array that looked something like:

```
[rewrites] => Array
  (
    [1835] => Array        --> Original (English) set as default
      (
        [0] => de/civicrm/
        [1] => fr/civicrm/
        [2] => civicrm/
        [4] => de/civicrm-de/
        [5] => fr/civicrm-fr/
      )

    [1858] => Array        --> French
      (
        [0] => fr/civicrm/
        [1] => fr/civicrm-fr/
      )

    [1861] => Array        --> German
      (
        [0] => de/civicrm/
        [1] => de/civicrm-de/
      )

  )
```

For WPML with "Different languages in directories" this translates to:

```
[rewrites] => Array
  (
    [1833] => Array        --> Original
      (
        [0] => en/civicrm/
        [2] => fr/civicrm/
        [3] => civicrm/
        [8] => civicrm-fr/
        [9] => fr/civicrm-fr/
        [10] => civicrm-de/
      )

    [1923] => Array        --> French
      (
        [0] => fr/civicrm/
        [1] => civicrm-fr/
        [2] => fr/civicrm-fr/
      )

    [1924] => Array        --> German set as default
      (
        [0] => civicrm/
        [1] => civicrm-de/
      )

  )
```

Bear in mind that if the slugs of the translated Base Pages are identical, then the duplicates will be stripped out and only unique rules will be added. Also bear in mind that the "naked" `civicrm` slug reflects the default language and must be correctly assigned as such. The updated code implements this rewrite rule structure and seems pretty robust in my testing.

I have also made some changes to the way in which the Base Page URL is filtered, largely due to wanting to avoid directly manipulating URLs. The effect of this is that no matter what settings are applied as detailed above, switching the language in the WPML admin bar dropdown produces front-end Base Page URLs in the chosen language - or the default language when "All Languages" is selected.

Lastly, doing all of the above makes possible a reliable Language Switcher that does not touch `$_SERVER` or `$_GET` but makes use of existing code in CiviCRM and WPML instead. One neat thing about this is that the language can be switched during a CiviCRM process (e.g. making a donation or registering for an event) without resetting the process.

Happy testing!